### PR TITLE
Fix storage module arguments in main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -154,12 +154,6 @@ module "storage" {
   name_prefix   = local.name_prefix
   common_labels = local.common_labels
   
-  # Storage configuration
-  storage_config = var.storage_config
-  
-  # Service account for storage access
-  storage_admin_email = module.iam.storage_admin_email
-  
   depends_on = [module.iam]
 }
 


### PR DESCRIPTION
## Summary
- Fixed incorrect storage module arguments in main.tf
- Removed non-existent variables (storage_config, storage_admin_email) that were causing module errors

## Test plan
- [ ] Run `terraform init` to verify module can be initialized
- [ ] Run `terraform validate` to ensure configuration is valid
- [ ] Run `terraform plan` to verify no errors with storage module

🤖 Generated with [Claude Code](https://claude.ai/code)